### PR TITLE
Report error in addition to success/ignored/failure

### DIFF
--- a/src/main/kotlin/io/github/wadoon/keycitool/Checker.kt
+++ b/src/main/kotlin/io/github/wadoon/keycitool/Checker.kt
@@ -310,8 +310,8 @@ class Checker : CliktCommand() {
             }
             printm(
                 "[INFO] Summary for $inputFile: " +
-                    "(successful/ignored/failure) " +
-                    "(${colorfg(successful, GREEN)}/${colorfg(ignored, BLUE)}/${colorfg(failure, RED)})",
+                    "(successful/ignored/failure/error) " +
+                    "(${colorfg(successful, GREEN)}/${colorfg(ignored, BLUE)}/${colorfg(failure, RED)}/${colorfg(error, RED)})",
             )
             if (failure != 0) {
                 err("$inputFile failed!")


### PR DESCRIPTION
Errors because of thrown exception and similar were counted but not reported. For a long list of proof-obligations one could miss problems when just looking at the summary line. This PR adds the missing information
